### PR TITLE
Fix build with cmake ninja backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ file(COPY themes DESTINATION .)
 
 set(CURSES_NEED_WIDE TRUE)
 find_package(Curses REQUIRED)
-include_directories("$(CURSES_INCLUDE_DIR)")
+include_directories(${CURSES_INCLUDE_DIRS})
 
 include_directories(${CMAKE_BINARY_DIR}/src src)
 


### PR DESCRIPTION
This was previously using a make specific syntax for the include directories